### PR TITLE
feat: add "Teaching, Serving, Standing" blog post

### DIFF
--- a/content/articles/2026-05-27-teaching-serving-standing.md
+++ b/content/articles/2026-05-27-teaching-serving-standing.md
@@ -245,3 +245,39 @@ And again, thank you so very much!
 - Pray for health, safety, provision, and wisdom for our family as we continue
   to live and minister in the midst of war.
 - Pray for peace and liberty in Ukraine.
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/kids-facetime-ipad_iaxtnd" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/ice-cream-monster_h36qmd" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/gne-gift-bags_xvswoc" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/ugo-aid-boxes_zaq1k6" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/zhytomyr-missile-strike_s2xrwa" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/crowd-good-and-evil-books_vjllu7" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/nathan-preaching_ny0oep" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-romans-class_fpphg8" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-rebekah-slovakia_uzlrxy" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/mykolayiv-attack_wsexkq" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-preaching_yj0rjr" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/girls-singing_gzlkn0" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-oleks-alla_hthpat" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-village-books_eulzne" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-kels-winter-run_syjneb" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/krakow-airport_qwdonl" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/romans-site_iaurho" width="768" caption="CAPTION" />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/abbie-axel_nsa1kt" height="768" caption="CAPTION" />

--- a/content/articles/2026-05-27-teaching-serving-standing.md
+++ b/content/articles/2026-05-27-teaching-serving-standing.md
@@ -24,7 +24,10 @@ caption: >
 tags:
   - newsletter
   - ministry
-  - ukraine
+  - ugo
+  - good-and-evil
+  - family
+  - photos
 ---
 
 January 16, 2026 — 8:50 am.
@@ -73,7 +76,7 @@ Anytime our family is out and about at 9:00 am, we stop too. We stand in silence
 and solidarity with our Ukrainian friends, honoring their sacrifices and praying
 for an end to this terrible war.
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-rebekah-slovakia_uzlrxy" width="768" caption="Rebekah and I had a fun trip visiting friends in Slovakia and getting her new Ukrainian visa in Krakow. I'm pleased to report that her residency process was completed successfully." />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-rebekah-slovakia_uzlrxy" width="768" caption="Rebekah and I had a fun trip — visiting friends in Slovakia and picking up her new Ukrainian visa in Krakow. I’m pleased to report her residency process is now complete." />
 
 ## Romans Course
 
@@ -91,7 +94,7 @@ school, I was glad to be asked to teach through the book for our congregation.
 We meet on the last Saturday of every month — our pastor teaches through
 Genesis, and I teach through Romans.
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-romans-class_fpphg8" width="768" caption="Teaching through the book of Romans at our church in Lviv has been a fantastic opportunity, and I'm excited about the potential ministry impact this course will have in the future." />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-romans-class_fpphg8" width="768" caption="Teaching through the book of Romans at our church in Lviv has been a fantastic opportunity, and I’m excited about the impact this course could have down the road." />
 
 What makes this round exciting is how much further I can take the course with
 the tools now available to me. I’m filming in high-resolution video with clear
@@ -109,7 +112,7 @@ at my new
 
 <article-image publicId="OFReport/2026-05-27-teaching-serving-standing/romans-site_iaurho" width="600" />
 
-<article-callout content="Check out my new Discovering Romans course website!" :link="{ name: 'Discovering Romans', href: 'https://joshukraine.com/romans-course/' }" />
+<article-callout content="Check out my new _Discovering Romans_ course website!" :link="{ name: 'Discovering Romans', href: 'https://joshukraine.com/romans-course/' }" />
 
 ## UGO — 2025 Recap and 2026 Plans
 
@@ -134,7 +137,7 @@ organizations have stopped visiting in these later years of the war. Yet the
 needs remain dire, and russia has not let up on its attacks against the
 Ukrainian people.
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-village-books_eulzne" width="768" caption="After the Gospel message, Joshua introduces the Good and Evil book." />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-village-books_eulzne" width="768" caption="After the Gospel message, Joshua introduces the _Good and Evil_ book." />
 
 <article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-preaching_yj0rjr" width="768" caption="Joshua preaches the Gospel at the meeting in Zhytomyr." />
 
@@ -193,7 +196,7 @@ people every single day. Nevertheless, Ukrainians are fighting valiantly for
 their freedom and independence — and, slowly but surely, we believe the tide is
 turning.
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/mykolayiv-attack_wsexkq" width="768" caption="This city administration building in Mykolaiv still bears the scars of a russian missile attack from early in the war. The entire city council perished in the strike except for one man." />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/mykolayiv-attack_wsexkq" width="768" caption="This Mykolaiv city administration building still bears the scars of a russian missile attack from earlier in the war. The entire city council perished in the strike — all but one man." />
 
 On a brighter note, we want to reassure you that our family is safe. Power
 outages have been a real struggle these past couple of years, but God has
@@ -224,9 +227,9 @@ see what God has done in their lives, and we look forward to the days ahead as
 they begin a family of their own — serving the Lord and raising up a new
 generation to follow Christ.
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/abbie-axel_nsa1kt" height="768" caption="We are so excited to announce Abbie and Axel's engagement! 🥳 We will be flying back to Texas for the wedding on August 22nd. God is good! 🥰🙏🏻" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/abbie-axel_nsa1kt" height="768" caption="We are so excited to announce Abbie and Axel’s engagement! 🥳 We will be flying back to Texas for the wedding on August 22nd. God is good! 🥰🙏🏻" />
 
-<article-callout content="Check out their website! " :link="{ name: 'Abbie and Axel', href: 'https://jsua.co/abbie-axel' }" />
+<article-callout content="Visit their wedding site!" :link="{ name: 'Abbie and Axel', href: 'https://jsua.co/abbie-axel' }" />
 
 ## Kelsie’s Substack
 
@@ -238,7 +241,7 @@ though of course anyone is welcome to visit and have a look! We think you’ll
 enjoy the posts and photos, and Kelsie is excited to share more through this new
 channel in the months ahead.
 
-<article-callout content="Don't miss Kelsie's updates on her new Substack!" :link="{ name: 'Be of Good Courage', href: 'https://kelsiesteele.substack.com/' }" />
+<article-callout content="Don’t miss Kelsie’s updates on her new Substack!" :link="{ name: 'Be of Good Courage', href: 'https://kelsiesteele.substack.com/' }" />
 
 ## A Special Request to Our Donors ❤️
 
@@ -272,20 +275,20 @@ And again, thank you so very much!
 
 <article-callout content="Keep scrolling for more photos from our family and ministry!" />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/gne-gift-bags_xvswoc" width="768" caption="One of Kelsie's ministry projects this year was a round of Christmas gift bags for friends, neighbors, and acquaintances in our area. Each bag contained a note from our family, a variety of hand-baked goodies, and a copy of Good and Evil in Ukrainian." />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/gne-gift-bags_xvswoc" width="768" caption="One of Kelsie’s ministry projects this past Christmas was a batch of gift bags for friends, neighbors, and acquaintances in our area. Each bag contained a note from our family, a variety of homemade baked goodies, a Scripture magnet, and a copy of _Good and Evil_ in Ukrainian." />
 
 <article-image publicId="OFReport/2026-05-27-teaching-serving-standing/kids-facetime-ipad_iaxtnd" width="768" caption="Storytime with Baba (grandmother) over FaceTime! 🥰" />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/krakow-airport_qwdonl" width="768" caption="Kelsie recently flew to the States for a brief visit with her parents. While we were in Krakow to take her to the airport, we took two of the kids to update their passports at the American consulate there. Missionary life is never dull!" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/krakow-airport_qwdonl" width="768" caption="Kelsie recently flew to the States for a brief visit with her parents. While we were in Krakow to see her off, we also brought two of the kids along to update their passports at the American consulate. Missionary life is never dull!" />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/girls-singing_gzlkn0" width="768" caption="As our church has lost more and more men to the war effort, our family has stepped in to help fill in the gaps. One way we've been able to serve is through music. In this photo, Melissa, Rebekah, Lydia, and Hosanna sing a special on a Sunday morning." />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/girls-singing_gzlkn0" width="768" caption="As our church has lost more and more men to the war effort, our family has stepped in to help fill in the gaps. One way we’ve been able to serve is through music. In this photo, Melissa, Rebekah, Lydia, and Hosanna sing a special on a Sunday morning." />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/zhytomyr-missile-strike_s2xrwa" width="768" caption="Someone's home once stood here. Then the russians came with their missiles and destroyed everything." />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/zhytomyr-missile-strike_s2xrwa" width="768" caption="Someone’s home once stood here. Then the russians came with their missiles and destroyed everything." />
 
 <article-image publicId="OFReport/2026-05-27-teaching-serving-standing/nathan-preaching_ny0oep" width="768" caption="Nathan preaches the Gospel at the meeting in Zhytomyr." />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-oleks-alla_hthpat" width="768" caption="Our dear friends Oleksandr and Alla live with their six children in Zhytomyr, which is much closer to the front lines than we are in Lviv. Oleksandr is an active and faithful missionary, and he has been our primary guide and coordinator for the past two UGO projects." />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-oleks-alla_hthpat" width="768" caption="Our dear friends, Oleksandr and Alla, live with their six children in Zhytomyr — much closer to the front lines than we are in Lviv. Oleksandr is a faithful missionary and has been our primary guide and coordinator for the past two UGO projects." />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-kels-winter-run_syjneb" width="768" caption="Kelsie and I still enjoy running together even when it snowing outside!" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-kels-winter-run_syjneb" width="768" caption="Kelsie and I still enjoy running together even when it’s snowing outside!" />
 
 <article-image publicId="OFReport/2026-05-27-teaching-serving-standing/ice-cream-monster_h36qmd" width="768" caption="Some of us get really excited about ice cream!" />

--- a/content/articles/2026-05-27-teaching-serving-standing.md
+++ b/content/articles/2026-05-27-teaching-serving-standing.md
@@ -1,0 +1,247 @@
+---
+title: 'Teaching, Serving, Standing'
+date: '2026-05-27'
+author: 'Joshua Steele'
+cover: 'https://res.cloudinary.com/dnkvsijzu/image/upload/v1779824708/OFReport/2026-05-27-teaching-serving-standing/ofr-apr-may-cover_livdau'
+pdf: 'OFR-Apr-May-2026.pdf'
+preview: >
+  January 16, 2026 — 8:50 am. Once again, we were headed to the Polish border.
+  Rebekah would soon turn 18, and so it was time to visit the Ukrainian
+  consulate in Krakow to get her a visa. Anya, a Ukrainian friend, had come
+  along for the ride. The morning was crisp; the roads, thankfully, clear. As
+  the three of us sped toward the border, conversation lulled, and my mind began
+  to wander. I’d driven this route so often I could almost do it in my sleep.
+  Almost. No sleep now, though — stay awake. Eyes on the road. We clipped along
+  in our blue Ford van at a comfortable 100 kph (62 mph).
+
+  Suddenly, I snapped alert: 8:56 am. Four minutes left...
+caption: >
+  The war in Ukraine grinds on, but despite the sorrow and tragedy, we continue
+  to be amazed at God’s faithfulness and the doors He is opening for our family
+  to share the Gospel. In this special issue of Overseas Field Report, we’d like
+  to show you some of what God has been doing in Ukraine — and some of the
+  exciting opportunities we see on the horizon.
+tags:
+  - newsletter
+  - ministry
+  - ukraine
+---
+
+January 16, 2026 — 8:50 am.
+
+Once again, we were headed to the Polish border. Rebekah would soon turn 18, and
+so it was time to visit the Ukrainian consulate in Krakow to get her a visa.
+Anya, a Ukrainian friend, had come along for the ride. The morning was crisp;
+the roads, thankfully, clear. As the three of us sped toward the border,
+conversation lulled, and my mind began to wander. I’d driven this route so often
+I could almost do it in my sleep. Almost. No sleep now, though — stay awake.
+Eyes on the road. We clipped along in our blue Ford van at a comfortable 100 kph
+(62 mph).
+
+<article-callout content="OFR-Apr-May-2026.pdf" :download="true" />
+
+Suddenly, I snapped alert: 8:56 am. Four minutes left. I couldn’t remember this
+ever happening on a highway. This was a newer road, and by Ukrainian standards,
+we were moving fast. I glanced in the rear-view mirror. A van rode close behind,
+clearly itching to pass. Had he noticed the time?
+
+Oncoming traffic was steady. As usual on a weekday morning, everyone was in a
+hurry. I felt my heart rate climb. I knew what I needed to do, but we were on
+the highway. Cars were moving too fast. This could be dangerous.
+
+8:58 am. The other van was still behind me, still moving full speed. Less than
+two minutes left. Does he know? Will he stop? Then I had an idea. I switched on
+my emergency flashers. Almost immediately, he slowed. Maybe he got the hint?
+Cars in the oncoming lane still whizzed by.
+
+8:59 am. It didn’t matter. This was important. With less than 30 seconds to go,
+I applied the brakes — not suddenly, but deliberately. To my relief, the other
+van followed, slowing to match my pace. Seconds later, we were both at a
+complete stop. In the oncoming lane, a few cars turned on their flashers; all of
+them stopped.
+
+9:00 am. I opened the driver’s door and stepped out into the road. Other drivers
+did the same. Cold though it was, I removed my stocking cap and stood
+motionless. All was silent. Right in the middle of a busy Ukrainian highway, on
+a Friday morning, with no accident in sight, the entire flow of traffic stood
+still.
+
+Every day in Ukraine, at 9:00 am, life stops for one minute as the nation stands
+in silence to honor those who have perished because of russia’s aggression.
+
+Anytime our family is out and about at 9:00 am, we stop too. We stand in silence
+and solidarity with our Ukrainian friends, honoring their sacrifices and praying
+for an end to this terrible war.
+
+## Romans Class
+
+I still remember the first time I heard Mike Pearl teach from the book of
+Romans. I was twelve, and my parents had brought me to a small Bible study at
+the country house of one of the families in our church. Several of us sat around
+the living room in front of a big wood stove while Mike taught from a chair off
+to one side, working through Romans verse by verse. In the years that followed,
+as Mike discipled me in Bible study and evangelism, I learned not just the
+doctrinal framework of Romans but how to study the Scriptures for myself.
+
+I’ve had the chance to teach Romans many times since — both to individuals I was
+discipling and to larger audiences. So when our church recently started a Bible
+school, I was glad to be asked to teach through the book for our congregation.
+We meet on the last Saturday of every month — our pastor teaching through
+Genesis, and me through Romans.
+
+What makes this round exciting is how much further I can take the course with
+the tools now available to me. I’m filming in high-resolution video with clear
+audio, and every lecture comes with engaging handouts to help students remember
+the highlights. I’m also writing a multiple-choice quiz for each lecture, with
+an eye toward eventually adapting the whole course for our _Bible First Online_
+platform.
+
+The turnout from our church has been really encouraging, and I’m just as excited
+about the reach this course could have down the road. The teaching is all in
+Ukrainian, of course, but if you’d like to listen in, YouTube now offers
+translated subtitles. You can find the videos and all the accompanying materials
+at my new
+[_Discovering Romans_ website](https://joshukraine.com/romans-course/).
+
+## UGO — 2025 Recap and 2026 Plans
+
+In mid-October of last year, we carried out our second major project under our
+new Ukraine Gospel Outreach (UGO) initiative — and it was a runaway success.
+Here’s a quick recap of what the team accomplished over those seven days:
+
+- We visited 11 villages in southern Ukraine, mostly in the Mykolaiv region.
+- After returning to north-central Ukraine, we held an outreach in a 12th
+  village and a final meeting in the city of Zhytomyr.
+- Attendance was strong throughout — an average of 50–100 people per meeting,
+  and around 250 at that final gathering in Zhytomyr.
+- We shipped 1,000 copies of the _Good and Evil_ book, most of which we
+  distributed across these villages.
+- We handed out roughly 1,000 boxes of humanitarian aid, along with extras like
+  bags of rice.
+- On more than one occasion, we used our van to carry hundreds of kilograms of
+  freshly baked bread to people along our route.
+
+One thing we heard repeatedly from locals this time: many of the larger aid
+organizations have stopped visiting in these later years of the war. Yet the
+needs remain dire, and russia has not let up on its attacks against the
+Ukrainian people.
+
+This year, we’re once again planning to take a team into the de-occupied zones
+of southern Ukraine for evangelism and humanitarian aid. We don’t have exact
+dates yet, but our target window is late October or early November. We’ll share
+more details as we firm up our plans.
+
+Our goals remain the same as before: to bring the gospel to people across
+Ukraine and to provide humanitarian aid to those in need. We’ll again pack and
+ship as many aid boxes as we can — each one costs around $20 to assemble. Many
+of you have reached out in the past wanting to help with these boxes, and if
+you’d like to be part of this work, you can donate through our nonprofit website
+at [euroteamoutreach.org/donate](https://euroteamoutreach.org/donate). If you
+have questions about how the projects work or how to get involved, please
+[don’t hesitate to reach out](/contact).
+
+Want to see the October 2025 project for yourself? Check out our
+[YouTube playlist](https://youtube.com/playlist?list=PLwBim7LWPkXWNlbUWqyRbQACx3p7EG4Wt).
+
+## Good and Evil Distributor Network
+
+A couple of months after last year’s UGO project wrapped up, we finally received
+the rest of our latest _Good and Evil_ printing. Some of these books are going
+out as single copies to individual Ukrainians, as we’ve done for years, but
+we’ve set aside a large quantity for something bigger: the relaunch of our _Good
+and Evil_ Distributor Network.
+
+We first launched this program shortly after the start of russia’s full-scale
+invasion in 2022. At the time, donations allowed us to print 15,000 copies of
+the _Good and Evil_ book, and through a wide network of distributors, we placed
+every last one across the length and breadth of the country. Eventually, with
+our stock exhausted, we had to wind the program down. Now, with this latest
+shipment in hand, we’re laying the groundwork to bring it back.
+
+The first time around, we ran everything through a Google Form and a tangle of
+spreadsheets. It worked in a pinch, but it was chaotic and hard to track. So
+this time we’ve built a proper network-management application — one that gives
+us far better visibility into where books are going and stronger accountability
+with our distributors. The app is built and currently in testing. We’re
+encouraged by how it’s coming together and eager to see what God will continue
+to do with the _Good and Evil_ book here in Ukraine.
+
+## War and Safety
+
+Over the past few months, I haven’t written about the war as often as I once
+did. It hasn’t been a deliberate choice so much as a result of fatigue and
+sadness. When you live with war day in and day out, it grows wearying and hard
+to talk about.
+
+But the situation on the ground hasn’t changed. russia presses on with its
+invasion, bringing the full might of its military to bear against the Ukrainian
+people every single day. Nevertheless, Ukrainians are fighting valiantly for
+their freedom and independence — and, slowly but surely, we believe the tide is
+turning.
+
+On a brighter note, we want to reassure you that our family is safe. Power
+outages have been a real struggle these past couple of years, but God has
+provided some in-home backup battery units that keep our lights on most of the
+time. The outages come and go, and the air raids too, but God is faithful. He
+has protected us, and we trust He will continue to do so.
+
+If you love light and freedom, we urge you to stand with Ukraine and to reject
+the false narratives that would justify the evil perpetrated by Putin and those
+who follow him. And please keep praying for us as we strive to share the light
+of Christ with Ukrainians.
+
+## Abigail’s Engagement and Wedding
+
+We are very excited to announce that our eldest daughter, Abigail, is now
+engaged to be married! Her fiancé, Axel Alvarenga, approached me about two years
+ago and expressed his desire to begin the relationship. It’s been quite a
+journey since then, and we’ve seen both Abbie and Axel grow in that time. We are
+convinced that God’s hand is in this, and Kelsie and I have given our full
+blessing for them to marry.
+
+Very soon, our whole family will travel back to Texas to join Abbie and Axel for
+their wedding, which they’re planning for August 22. You can follow their
+updates at [jsua.co/abbie-axel](https://jsua.co/abbie-axel). We are thrilled to
+see what God has done in their lives, and we look forward to the days ahead as
+they begin a family of their own — serving the Lord and raising up a new
+generation to follow Christ.
+
+## Kelsie’s Substack
+
+For those who haven’t yet heard, Kelsie has launched her own
+[Substack](https://kelsiesteele.substack.com/), where she’s writing monthly. Her
+goal is to share reflections from her Bible studies along with updates from our
+family life here in Ukraine. It’s written with the ladies especially in mind,
+though of course anyone is welcome to visit and have a look! We think you’ll
+enjoy the posts and photos, and Kelsie is excited to share more through this new
+channel in the months ahead.
+
+## A Special Request to Our Donors ❤️
+
+To everyone who gives to support our ministry — thank you! Your generosity is a
+gift we never take for granted, and we wish we could thank each of you directly.
+
+We can reach some of you via email or text message. But many of the donations we
+receive arrive as paper checks in the mail, leaving us with no practical way to
+reach you. In the past, we’ve tried sending handwritten cards, but postage rates
+from Ukraine have climbed, and we’re never quite sure our cards arrive.
+
+So if you’re one of those faithful supporters who donates by check, we’d love to
+get your email so we can say “thank you.” If you’re willing, drop us a line
+through the [contact form](/contact) on our blog, and we’ll take it from there.
+And again, thank you so very much!
+
+## How You Can Pray
+
+- Pray for wisdom and clarity as I continue to develop my _Discovering Romans_
+  course for Ukrainians.
+- Pray that God will bless and multiply our efforts with the relaunch of our
+  _Good and Evil_ Distributor Network.
+- Pray for direction, provision, and safety as we plan our next UGO project this
+  fall.
+- Pray for Abbie and Axel as they prepare for their August wedding and their new
+  life together.
+- Pray for our family as we travel to the US this summer.
+- Pray for health, safety, provision, and wisdom for our family as we continue
+  to live and minister in the midst of war.
+- Pray for peace and liberty in Ukraine.

--- a/content/articles/2026-05-27-teaching-serving-standing.md
+++ b/content/articles/2026-05-27-teaching-serving-standing.md
@@ -73,7 +73,7 @@ Anytime our family is out and about at 9:00 am, we stop too. We stand in silence
 and solidarity with our Ukrainian friends, honoring their sacrifices and praying
 for an end to this terrible war.
 
-## Romans Class
+## Romans Course
 
 I still remember the first time I heard Mike Pearl teach from the book of
 Romans. I was twelve, and my parents had brought me to a small Bible study at

--- a/content/articles/2026-05-27-teaching-serving-standing.md
+++ b/content/articles/2026-05-27-teaching-serving-standing.md
@@ -5,14 +5,14 @@ author: 'Joshua Steele'
 cover: 'https://res.cloudinary.com/dnkvsijzu/image/upload/v1779824708/OFReport/2026-05-27-teaching-serving-standing/ofr-apr-may-cover_livdau'
 pdf: 'OFR-Apr-May-2026.pdf'
 preview: >
-  January 16, 2026 — 8:50 am. Once again, we were headed to the Polish border.
-  Rebekah would soon turn 18, and so it was time to visit the Ukrainian
-  consulate in Krakow to get her a visa. Anya, a Ukrainian friend, had come
-  along for the ride. The morning was crisp; the roads, thankfully, clear. As
-  the three of us sped toward the border, conversation lulled, and my mind began
-  to wander. I’d driven this route so often I could almost do it in my sleep.
-  Almost. No sleep now, though — stay awake. Eyes on the road. We clipped along
-  in our blue Ford van at a comfortable 100 kph (62 mph).
+  January 16, 2026 — 8:50 am. We were seated in our blue Ford van, headed once
+  again to the Polish border. Rebekah would soon turn 18, and so it was time to
+  visit the Ukrainian consulate in Krakow to get her a visa. Anya, a Ukrainian
+  friend, had come along for the ride. The morning was crisp; the roads,
+  thankfully, clear. As the three of us sped toward the border, conversation
+  lulled, and my mind began to wander. I’d driven this route so often I could
+  almost do it in my sleep. Almost. No sleep now, though — stay awake. Eyes on
+  the road. We clipped along at a comfortable 100 kph (62 mph).
 
   Suddenly, I snapped alert: 8:56 am. Four minutes left...
 caption: >
@@ -29,14 +29,14 @@ tags:
 
 January 16, 2026 — 8:50 am.
 
-Once again, we were headed to the Polish border. Rebekah would soon turn 18, and
-so it was time to visit the Ukrainian consulate in Krakow to get her a visa.
-Anya, a Ukrainian friend, had come along for the ride. The morning was crisp;
-the roads, thankfully, clear. As the three of us sped toward the border,
-conversation lulled, and my mind began to wander. I’d driven this route so often
-I could almost do it in my sleep. Almost. No sleep now, though — stay awake.
-Eyes on the road. We clipped along in our blue Ford van at a comfortable 100 kph
-(62 mph).
+We were seated in our blue Ford van, headed once again to the Polish border.
+Rebekah would soon turn 18, and so it was time to visit the Ukrainian consulate
+in Krakow to get her a visa. Anya, a Ukrainian friend, had come along for the
+ride. The morning was crisp; the roads, thankfully, clear. As the three of us
+sped toward the border, conversation lulled, and my mind began to wander. I’d
+driven this route so often I could almost do it in my sleep. Almost. No sleep
+now, though — stay awake. Eyes on the road. We clipped along at a comfortable
+100 kph (62 mph).
 
 <article-callout content="OFR-Apr-May-2026.pdf" :download="true" />
 
@@ -86,8 +86,8 @@ doctrinal framework of Romans but how to study the Scriptures for myself.
 I’ve had the chance to teach Romans many times since — both to individuals I was
 discipling and to larger audiences. So when our church recently started a Bible
 school, I was glad to be asked to teach through the book for our congregation.
-We meet on the last Saturday of every month — our pastor teaching through
-Genesis, and me through Romans.
+We meet on the last Saturday of every month — our pastor teaches through
+Genesis, and I teach through Romans.
 
 What makes this round exciting is how much further I can take the course with
 the tools now available to me. I’m filming in high-resolution video with clear

--- a/content/articles/2026-05-27-teaching-serving-standing.md
+++ b/content/articles/2026-05-27-teaching-serving-standing.md
@@ -73,6 +73,8 @@ Anytime our family is out and about at 9:00 am, we stop too. We stand in silence
 and solidarity with our Ukrainian friends, honoring their sacrifices and praying
 for an end to this terrible war.
 
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-rebekah-slovakia_uzlrxy" width="768" caption="Rebekah and I had a fun trip visiting friends in Slovakia and getting her new Ukrainian visa in Krakow. I'm pleased to report that her residency process was completed successfully." />
+
 ## Romans Course
 
 I still remember the first time I heard Mike Pearl teach from the book of
@@ -89,6 +91,8 @@ school, I was glad to be asked to teach through the book for our congregation.
 We meet on the last Saturday of every month — our pastor teaches through
 Genesis, and I teach through Romans.
 
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-romans-class_fpphg8" width="768" caption="Teaching through the book of Romans at our church in Lviv has been a fantastic opportunity, and I'm excited about the potential ministry impact this course will have in the future." />
+
 What makes this round exciting is how much further I can take the course with
 the tools now available to me. I’m filming in high-resolution video with clear
 audio, and every lecture comes with engaging handouts to help students remember
@@ -102,6 +106,10 @@ Ukrainian, of course, but if you’d like to listen in, YouTube now offers
 translated subtitles. You can find the videos and all the accompanying materials
 at my new
 [_Discovering Romans_ website](https://joshukraine.com/romans-course/).
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/romans-site_iaurho" width="600" />
+
+<article-callout content="Check out my new Discovering Romans course website!" :link="{ name: 'Discovering Romans', href: 'https://joshukraine.com/romans-course/' }" />
 
 ## UGO — 2025 Recap and 2026 Plans
 
@@ -125,6 +133,10 @@ One thing we heard repeatedly from locals this time: many of the larger aid
 organizations have stopped visiting in these later years of the war. Yet the
 needs remain dire, and russia has not let up on its attacks against the
 Ukrainian people.
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-village-books_eulzne" width="768" caption="After the Gospel message, Joshua introduces the Good and Evil book." />
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-preaching_yj0rjr" width="768" caption="Joshua preaches the Gospel at the meeting in Zhytomyr." />
 
 This year, we’re once again planning to take a team into the de-occupied zones
 of southern Ukraine for evangelism and humanitarian aid. We don’t have exact
@@ -166,6 +178,8 @@ with our distributors. The app is built and currently in testing. We’re
 encouraged by how it’s coming together and eager to see what God will continue
 to do with the _Good and Evil_ book here in Ukraine.
 
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/crowd-good-and-evil-books_vjllu7" width="768" />
+
 ## War and Safety
 
 Over the past few months, I haven’t written about the war as often as I once
@@ -179,6 +193,8 @@ people every single day. Nevertheless, Ukrainians are fighting valiantly for
 their freedom and independence — and, slowly but surely, we believe the tide is
 turning.
 
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/mykolayiv-attack_wsexkq" width="768" caption="This city administration building in Mykolaiv still bears the scars of a russian missile attack from early in the war. The entire city council perished in the strike except for one man." />
+
 On a brighter note, we want to reassure you that our family is safe. Power
 outages have been a real struggle these past couple of years, but God has
 provided some in-home backup battery units that keep our lights on most of the
@@ -189,6 +205,8 @@ If you love light and freedom, we urge you to stand with Ukraine and to reject
 the false narratives that would justify the evil perpetrated by Putin and those
 who follow him. And please keep praying for us as we strive to share the light
 of Christ with Ukrainians.
+
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/ugo-aid-boxes_zaq1k6" width="768" caption="Handing out aid boxes as part of the 2025 UGO project in southern Ukraine" />
 
 ## Abigail’s Engagement and Wedding
 
@@ -206,6 +224,10 @@ see what God has done in their lives, and we look forward to the days ahead as
 they begin a family of their own — serving the Lord and raising up a new
 generation to follow Christ.
 
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/abbie-axel_nsa1kt" height="768" caption="We are so excited to announce Abbie and Axel's engagement! 🥳 We will be flying back to Texas for the wedding on August 22nd. God is good! 🥰🙏🏻" />
+
+<article-callout content="Check out their website! " :link="{ name: 'Abbie and Axel', href: 'https://jsua.co/abbie-axel' }" />
+
 ## Kelsie’s Substack
 
 For those who haven’t yet heard, Kelsie has launched her own
@@ -215,6 +237,8 @@ family life here in Ukraine. It’s written with the ladies especially in mind,
 though of course anyone is welcome to visit and have a look! We think you’ll
 enjoy the posts and photos, and Kelsie is excited to share more through this new
 channel in the months ahead.
+
+<article-callout content="Don't miss Kelsie's updates on her new Substack!" :link="{ name: 'Be of Good Courage', href: 'https://kelsiesteele.substack.com/' }" />
 
 ## A Special Request to Our Donors ❤️
 
@@ -246,38 +270,22 @@ And again, thank you so very much!
   to live and minister in the midst of war.
 - Pray for peace and liberty in Ukraine.
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/kids-facetime-ipad_iaxtnd" width="768" caption="CAPTION" />
+<article-callout content="Keep scrolling for more photos from our family and ministry!" />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/ice-cream-monster_h36qmd" width="768" caption="CAPTION" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/gne-gift-bags_xvswoc" width="768" caption="One of Kelsie's ministry projects this year was a round of Christmas gift bags for friends, neighbors, and acquaintances in our area. Each bag contained a note from our family, a variety of hand-baked goodies, and a copy of Good and Evil in Ukrainian." />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/gne-gift-bags_xvswoc" width="768" caption="CAPTION" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/kids-facetime-ipad_iaxtnd" width="768" caption="Storytime with Baba (grandmother) over FaceTime! 🥰" />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/ugo-aid-boxes_zaq1k6" width="768" caption="CAPTION" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/krakow-airport_qwdonl" width="768" caption="Kelsie recently flew to the States for a brief visit with her parents. While we were in Krakow to take her to the airport, we took two of the kids to update their passports at the American consulate there. Missionary life is never dull!" />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/zhytomyr-missile-strike_s2xrwa" width="768" caption="CAPTION" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/girls-singing_gzlkn0" width="768" caption="As our church has lost more and more men to the war effort, our family has stepped in to help fill in the gaps. One way we've been able to serve is through music. In this photo, Melissa, Rebekah, Lydia, and Hosanna sing a special on a Sunday morning." />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/crowd-good-and-evil-books_vjllu7" width="768" caption="CAPTION" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/zhytomyr-missile-strike_s2xrwa" width="768" caption="Someone's home once stood here. Then the russians came with their missiles and destroyed everything." />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/nathan-preaching_ny0oep" width="768" caption="CAPTION" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/nathan-preaching_ny0oep" width="768" caption="Nathan preaches the Gospel at the meeting in Zhytomyr." />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-romans-class_fpphg8" width="768" caption="CAPTION" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-oleks-alla_hthpat" width="768" caption="Our dear friends Oleksandr and Alla live with their six children in Zhytomyr, which is much closer to the front lines than we are in Lviv. Oleksandr is an active and faithful missionary, and he has been our primary guide and coordinator for the past two UGO projects." />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-rebekah-slovakia_uzlrxy" width="768" caption="CAPTION" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-kels-winter-run_syjneb" width="768" caption="Kelsie and I still enjoy running together even when it snowing outside!" />
 
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/mykolayiv-attack_wsexkq" width="768" caption="CAPTION" />
-
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-preaching_yj0rjr" width="768" caption="CAPTION" />
-
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/girls-singing_gzlkn0" width="768" caption="CAPTION" />
-
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-oleks-alla_hthpat" width="768" caption="CAPTION" />
-
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/joshua-village-books_eulzne" width="768" caption="CAPTION" />
-
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/josh-kels-winter-run_syjneb" width="768" caption="CAPTION" />
-
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/krakow-airport_qwdonl" width="768" caption="CAPTION" />
-
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/romans-site_iaurho" width="768" caption="CAPTION" />
-
-<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/abbie-axel_nsa1kt" height="768" caption="CAPTION" />
+<article-image publicId="OFReport/2026-05-27-teaching-serving-standing/ice-cream-monster_h36qmd" width="768" caption="Some of us get really excited about ice cream!" />

--- a/data/archives.json
+++ b/data/archives.json
@@ -1,4 +1,11 @@
 {
+  "2026": [
+    {
+      "title": "Teaching, Serving, Standing",
+      "issue": "Apr/May 2026",
+      "file": "OFR-Apr-May-2026.pdf"
+    }
+  ],
   "2025": [
     {
       "title": "Announcing Ukraine Gospel Outreach",


### PR DESCRIPTION
## Summary

- April/May 2026 print newsletter as a blog post, covering Romans Course, UGO recap and 2026 plans, _Good and Evil_ Distributor Network, war update, Abigail's engagement, Kelsie's Substack, donor request, and prayer items.
- 18 article images distributed throughout, with captions.
- Wording verified against the print PDF via sentence-level diff.

## Test plan

- [x] `yarn dev` and load `/blog/2026-05-27-teaching-serving-standing/` — verify layout, all images render, and the article-callout / PDF download link works.
- [x] Confirm internal link to `/contact` resolves on the rendered page.
- [x] Confirm external links open correctly: jsua.co/abbie-axel, euroteamoutreach.org, the YouTube playlist, the Romans course site, and Kelsie's Substack.
- [x] Spot-check the post on the blog index (correct preview blurb, cover image, tags).