### PR TITLE
fix: keep internal links from opening in a new tab

### DIFF
--- a/config/build.js
+++ b/config/build.js
@@ -23,7 +23,7 @@ export default {
       options: {
         mode: [Mode.VUE_COMPONENT],
         markdownIt: md.use(mila, {
-          pattern: /^https?:\/\//,
+          matcher: (href) => /^https?:\/\//.test(href),
           attrs: {
             target: '_blank',
             rel: 'noopener noreferrer',

--- a/mixins/markdownit.js
+++ b/mixins/markdownit.js
@@ -7,7 +7,7 @@ const md = require('markdown-it')({
 const mila = require('markdown-it-link-attributes');
 
 md.use(mila, {
-  pattern: /^https?:\/\//,
+  matcher: (href) => /^https?:\/\//.test(href),
   attrs: {
     target: '_blank',
     rel: 'noopener noreferrer',


### PR DESCRIPTION
## Summary

- `markdown-it-link-attributes` v4 expects a `matcher` function, but both call sites pass `pattern` (a regex). The `pattern` key is silently ignored, so every article-pipeline link receives `target="_blank"` / `rel="noopener noreferrer"` regardless of whether it's external.
- Switch to the `matcher: (href) => /^https?:\/\//.test(href)` form in both `config/build.js` (article body) and `mixins/markdownit.js` (inline-markdown captions/callouts).
- After this fix, root-relative links like `/contact` will navigate in-tab as expected; external `https://…` links still open in a new tab.

## Test plan

- [x] Wait for the Netlify deploy preview.
- [x] On the preview of the most recent post (`/blog/2026-05-27-teaching-serving-standing/`), inspect the donor section's "contact form" link — confirm it has no `target` attribute and navigates in-tab.
- [x] Confirm an external link in the same post (e.g., `jsua.co/abbie-axel`, `kelsiesteele.substack.com`) still has `target="_blank"` and `rel="noopener noreferrer"`.
- [x] Spot-check an older article with internal links (e.g., `/blog/2023-04-03-ukrainian-angels/`) — same in-tab behavior expected.