### PR TITLE
fix: remove trailing /index.html from jsua.co video links

### DIFF
--- a/content/articles/2025-02-24-the-november-project.md
+++ b/content/articles/2025-02-24-the-november-project.md
@@ -108,7 +108,7 @@ Ukrainians and speaking their language. But more than anything, I long to see
 these precious people in heaven. To that end, I will continue laboring as long
 as God gives me breath.
 
-<article-callout content="Check out our collection of video updates shot during the trip!" :link="{ name: 'The November Project 2024', href: 'https://jsua.co/nov-proj-2024/index.html' }" />
+<article-callout content="Check out our collection of video updates shot during the trip!" :link="{ name: 'The November Project 2024', href: 'https://jsua.co/nov-proj-2024' }" />
 
 ## How You Can Pray
 
@@ -169,4 +169,4 @@ as God gives me breath.
 
 <article-image publicId="OFReport/2025-02-24-the-november-project/joshua-lady-good-evil-book_zwajny" width="768" caption="I don’t know her name, but I pray that one day it will be written in Heaven. The book she holds shows the way!" />
 
-<article-callout content="Don't forget to check out our collection of video updates shot during the trip!" :link="{ name: 'The November Project 2024', href: 'https://jsua.co/nov-proj-2024/index.html' }" />
+<article-callout content="Don't forget to check out our collection of video updates shot during the trip!" :link="{ name: 'The November Project 2024', href: 'https://jsua.co/nov-proj-2024' }" />


### PR DESCRIPTION
## Summary

Fixes a broken link in **The November Project** post. The two "video updates" callouts linked to `https://jsua.co/nov-proj-2024/index.html` — the trailing `/index.html` broke the jsua.co URL forwarding redirect. Both now point at the clean `https://jsua.co/nov-proj-2024` slug.

## Changes

- `content/articles/2025-02-24-the-november-project.md` (lines 111 and 172): drop trailing `/index.html` from both `jsua.co/nov-proj-2024` links.

## Audit

Swept every article for `jsua.co` links. The remaining ones are already clean — no trailing `/index.html`:

- `jsua.co/abbie-axel` (Teaching, Serving, Standing)
- `jsua.co/jan-2021-invitation` (Bible First Pioneers)

No other `index.html` strings exist anywhere in `content/`.
